### PR TITLE
Add support for HSRP routers

### DIFF
--- a/WinpcapPacketInterface.cpp
+++ b/WinpcapPacketInterface.cpp
@@ -102,6 +102,9 @@ void WinpcapPacketInterface::initialise (net::InetAddress target)
 		m_ethernetHeader.type = ETHERNET_TYPE_IP;
 		m_ethernetHeader.srcAddr = m_sourceMAC;
 		m_ethernetHeader.destAddr = m_destinationMAC;
+
+		//if (m_destinationMAC.isHSRP())
+		//	cout << "HSRP MAC Address detected!" << endl;
 	}
 }
 
@@ -130,11 +133,14 @@ bool WinpcapPacketInterface::recPacket (neo::MemoryBlock& buffer, net::InetAddre
 		{
 			packet::EthernetHeader* header = (packet::EthernetHeader*)packetData;
 			packet::IPHeader* ipheader = (packet::IPHeader*)(packetData + sizeof(packet::EthernetHeader));
-			if (header->srcAddr == m_destinationMAC && header->destAddr == m_sourceMAC && header->type == ETHERNET_TYPE_IP)
+			if (header->destAddr == m_sourceMAC && header->type == ETHERNET_TYPE_IP)
 			{
-				memcpy (buffer.getBlock(), packetData + sizeof(packet::EthernetHeader),  packetHeader->caplen - sizeof(packet::EthernetHeader));
-				from.setIPAddress(ipheader->sourceIP.get());
-				return true;
+				if (m_destinationMAC.isHSRP() || header->srcAddr == m_destinationMAC)
+				{
+					memcpy(buffer.getBlock(), packetData + sizeof(packet::EthernetHeader), packetHeader->caplen - sizeof(packet::EthernetHeader));
+					from.setIPAddress(ipheader->sourceIP.get());
+					return true;
+				}
 			}
 		}
 	}

--- a/packet/PacketDefs.h
+++ b/packet/PacketDefs.h
@@ -57,6 +57,21 @@ namespace packet
 			return memcmp(addr, that.addr, 6) == 0;
 		}
 
+		// HSRP v1 IP4 virtual MAC address range: 00:00:0c:07:ac:XX
+		// HSRP v2 IP4 virtual MAC address range: 00:00:0c:9f:fX:XX
+		bool isHSRP()
+		{
+			const char HSRPv1[] = "00:00:0c:07:ac";
+			const char HSRPv2[] = "00:00:0c:9f:f";
+
+			char buffer[32];
+			sprintf(buffer, "%02x:%02x:%02x:%02x:%02x:%02x", addr[0].get(), addr[1].get(), addr[2].get(), addr[3].get(), addr[4].get(), addr[5].get());
+
+			if ((memcmp(buffer, HSRPv1, sizeof(HSRPv1) - 1) == 0) || (memcmp(buffer, HSRPv2, sizeof(HSRPv2) - 1) == 0))
+				return 1;
+
+			return 0;
+		}
     };
 
     #define ETHERNET_TYPE_IP  0x800


### PR DESCRIPTION
Environments with HSRP routers will fail the MAC address check,
as the virtual MAC address returned by the ARP query will not
match the physical router MAC address in the inbound packets
